### PR TITLE
objectids "cache" option

### DIFF
--- a/js/app/main.js
+++ b/js/app/main.js
@@ -503,7 +503,9 @@ define(['lib/i18n.min!nls/resources.js', 'prepareAppConfigInfo', 'handleUserSign
         $("#surveyContainer").fadeTo(100, 0.0);
 
         // Get candidate property
-        dataAccess.getCandidate(prepareAppConfigInfo.appParams.randomizeSelection).then(function (candidate) {
+        dataAccess.getCandidate(
+            prepareAppConfigInfo.appParams.randomizeSelection, 
+            prepareAppConfigInfo.appParams.queryAllFeaturesMaxAgeInMilliseconds).then(function (candidate) {
             // obj:feature{}
             // attachments:[{id,url},...]
 

--- a/js/configuration.json
+++ b/js/configuration.json
@@ -12,9 +12,11 @@
         "overviewMapZoom": 16,
         "proxyProgram": "proxy/proxy.ashx",
 
-        "randomizeSelection": false,
+        "randomizeSelection": true,
         "allowGuestSubmissions": true,
         "thumbnailLimit": "1",
+
+        "queryAllFeaturesMaxAgeInMilliseconds": 600000,
 
         "showGuest": "true",
         "facebookAppId": "2065937150402544",


### PR DESCRIPTION
added option to configuration called "queryAllFeaturesMaxAgeInMilliseconds". This is the number of milliseconds to cache the list of all objectIds. This is to save time because on large datasets where many of the features do not have attachments, this query may happen multiple times each time a new location is loaded, slowing down the application. This variable is set in configuration.json and should generally be set to {boolean} false unless you are having loading speed issues when switching between images.

Caching these IDs has a slight downside that you increase the chance that 2 people taking the survey at the same time may get assigned the exact same image and thus waste a bit of time both filling out the survey. That's why this variable is a "max age" so that the list of objectids will refresh automatically after that amount of time even if the survey takers are not refreshing the page. I have it set for this project to 10 minutes but could be tinkered with to get the ideal balance of performance vs "concurrent work" trade-off.

@dalekunce please review
cc @JSteurer